### PR TITLE
CIRC-2415 hold shelf exp date, use-at-location

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/LoanPolicy.java
@@ -216,7 +216,7 @@ public class LoanPolicy extends Policy {
         (!request.hasItem() || itemId.equals(request.getItemId())));
   }
 
-  private JsonObject getLoansPolicy() {
+  public JsonObject getLoansPolicy() {
     return representation.getJsonObject(LOANS_POLICY_KEY);
   }
 
@@ -348,6 +348,16 @@ public class LoanPolicy extends Policy {
 
   public boolean isForUseAtLocation() {
     return getBooleanProperty(getLoansPolicy(), FOR_USE_AT_LOCATION);
+  }
+
+  public Period getHoldShelfExpiryPeriodForUseAtLocation() {
+    if (isForUseAtLocation()) {
+      JsonObject holdShelfExpiryPeriod = getObjectProperty(getLoansPolicy(), "holdShelfExpiryPeriodForUseAtLocation");
+      if (holdShelfExpiryPeriod != null) {
+        return Period.from(holdShelfExpiryPeriod);
+      }
+    }
+    return null;
   }
 
   public DueDateManagement getDueDateManagement() {

--- a/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
+++ b/src/main/java/org/folio/circulation/domain/representations/LoanProperties.java
@@ -37,6 +37,7 @@ public class LoanProperties {
   public static final String FOR_USE_AT_LOCATION = "forUseAtLocation";
   public static final String AT_LOCATION_USE_STATUS = "status";
   public static final String AT_LOCATION_USE_STATUS_DATE = "statusDate";
+  public static final String AT_LOCATION_USE_EXPIRY_DATE = "holdShelfExpirationDate";
   public static final String USAGE_STATUS_IN_USE = "In use";
   public static final String USAGE_STATUS_HELD = "Held";
   public static final String USAGE_STATUS_RETURNED = "Returned";

--- a/src/test/java/api/loans/LoansForUseAtLocationTests.java
+++ b/src/test/java/api/loans/LoansForUseAtLocationTests.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import static api.support.fixtures.ItemExamples.basedUponSmallAngryPlanet;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 public class LoansForUseAtLocationTests extends APITests {
   private ItemResource item;
@@ -77,7 +78,8 @@ public class LoansForUseAtLocationTests extends APITests {
       .withName("Reading room loans")
       .withDescription("Policy for items to be used at location")
       .rolling(Period.days(30))
-      .withForUseAtLocation(true);
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "DAYS"));
 
     use(forUseAtLocationPolicyBuilder);
 
@@ -91,10 +93,13 @@ public class LoansForUseAtLocationTests extends APITests {
       new HoldByBarcodeRequestBuilder(item.getBarcode()));
 
     JsonObject forUseAtLocation = holdResponse.getJson().getJsonObject("forUseAtLocation");
+
     assertThat("loan.forUseAtLocation",
       forUseAtLocation, notNullValue());
     assertThat("loan.forUseAtLocation.status",
       forUseAtLocation.getString("status"), Is.is("Held"));
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate"), notNullValue());
   }
 
   @Test
@@ -103,7 +108,8 @@ public class LoansForUseAtLocationTests extends APITests {
       .withName("Reading room loans")
       .withDescription("Policy for items to be used at location")
       .rolling(Period.days(30))
-      .withForUseAtLocation(true);
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "DAYS"));
 
     use(forUseAtLocationPolicyBuilder);
 
@@ -142,7 +148,8 @@ public class LoansForUseAtLocationTests extends APITests {
       .withName("Reading room loans")
       .withDescription("Policy for items to be used at location")
       .rolling(Period.days(30))
-      .withForUseAtLocation(true);
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "DAYS"));
 
     use(forUseAtLocationPolicyBuilder);
 
@@ -163,7 +170,8 @@ public class LoansForUseAtLocationTests extends APITests {
       .withName("Reading room loans")
       .withDescription("Policy for items to be used at location")
       .rolling(Period.days(30))
-      .withForUseAtLocation(true);
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "DAYS"));
 
     use(forUseAtLocationPolicyBuilder);
 
@@ -213,7 +221,8 @@ public class LoansForUseAtLocationTests extends APITests {
       .withName("Reading room loans")
       .withDescription("Policy for items to be used at location")
       .rolling(Period.days(30))
-      .withForUseAtLocation(true);
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "DAYS"));
 
     use(forUseAtLocationPolicyBuilder);
 
@@ -255,7 +264,8 @@ public class LoansForUseAtLocationTests extends APITests {
       .withName("Reading room loans")
       .withDescription("Policy for items to be used at location")
       .rolling(Period.days(30))
-      .withForUseAtLocation(true);
+      .withForUseAtLocation(true)
+      .withHoldShelfExpiryPeriodForUseAtLocation(Period.from(5, "DAYS"));
 
     use(forUseAtLocationPolicyBuilder);
 
@@ -275,6 +285,8 @@ public class LoansForUseAtLocationTests extends APITests {
       forUseAtLocation, notNullValue());
     assertThat("loan.forUseAtLocation.status",
       forUseAtLocation.getString("status"), Is.is("Returned"));
+    assertThat("loan.forUseAtLocation.holdShelfExpirationDate",
+      forUseAtLocation.getString("holdShelfExpirationDate"), nullValue());
   }
 
 }

--- a/src/test/java/api/support/builders/LoanPolicyBuilder.java
+++ b/src/test/java/api/support/builders/LoanPolicyBuilder.java
@@ -41,6 +41,7 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
   private final Integer itemLimit;
   private final Period gracePeriod;
   private final boolean forUseAtLocation;
+  private final Period holdShelfExpiryPeriodForUseAtLocation;
 
   public LoanPolicyBuilder() {
     this(UUID.randomUUID(),
@@ -67,7 +68,8 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       null,
       null,
       null,
-      false
+      false,
+      null
     );
   }
 
@@ -91,6 +93,7 @@ public class LoanPolicyBuilder extends JsonBuilder implements Builder {
       put(loansPolicy, "itemLimit", itemLimit);
       putIfNotNull(loansPolicy, "gracePeriod", gracePeriod, Period::asJson);
       put(loansPolicy, "forUseAtLocation", forUseAtLocation);
+      putIfNotNull(loansPolicy, "holdShelfExpiryPeriodForUseAtLocation", holdShelfExpiryPeriodForUseAtLocation, Period::asJson);
 
       //TODO: Replace with sub-builders
       if(Objects.equals(loansProfile, "Rolling")) {


### PR DESCRIPTION
Sets the expiration date on loans when a reading room item is put on hold for next use, if the policy has a `holdShelfExpiryPeriodForUseAtLocation` defined. 

Will simply add the period to the hold date, without considering closed days (to come).