### PR TITLE
Enable for-use-at-location

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2789,7 +2789,7 @@
       },
       {
         "name": "ENABLE_FOR_USE_AT_LOCATION",
-        "value": "false"
+        "value": "true"
       },
       {
         "name": "KAFKA_HOST",


### PR DESCRIPTION
After updating IDs fork of mod-circulation from folio-org, the for-use-at-location must be enabled again in the module descriptor. 
