### PR TITLE
Bring back workflows after syncing fork

### DIFF
--- a/.github/workflows/k8s-deploy-latest.yml
+++ b/.github/workflows/k8s-deploy-latest.yml
@@ -1,0 +1,26 @@
+# Very simple workflow to deploy the *latest* published container image with the 'latest' tag.
+# This does not post updated module descriptors to okapi, update permissions or enable
+# new versions of a module with the tenant.  If that is needed,  it should be done manually
+# via the Okapi API.
+
+name: k8s-deploy-latest
+
+env:
+  K8S_NAMESPACE: 'orchid-dev'
+  K8S_DEPLOYMENT: 'mod-sender-dev'
+
+on:
+  workflow_dispatch
+
+jobs:
+  k8s-deploy-latest:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy latest to K8s
+        uses: actions-hub/kubectl@v1.34.1
+        env:
+          KUBE_CONFIG: ${{ secrets.ORCHID_DEV_SA_KUBECONFIG }}
+        with:
+          args:
+            -n ${{ env.K8S_NAMESPACE }} rollout restart deployment ${{ env.K8S_DEPLOYMENT }}

--- a/.github/workflows/k8s-deploy-latest.yml
+++ b/.github/workflows/k8s-deploy-latest.yml
@@ -6,8 +6,8 @@
 name: k8s-deploy-latest
 
 env:
-  K8S_NAMESPACE: 'orchid-dev'
-  K8S_DEPLOYMENT: 'mod-sender-dev'
+  K8S_NAMESPACE: 'folio-dev-new'
+  K8S_DEPLOYMENT: 'mod-circulation-dev'
 
 on:
   workflow_dispatch
@@ -20,7 +20,7 @@ jobs:
       - name: Deploy latest to K8s
         uses: actions-hub/kubectl@v1.34.1
         env:
-          KUBE_CONFIG: ${{ secrets.ORCHID_DEV_SA_KUBECONFIG }}
+          KUBE_CONFIG: ${{ secrets.FOLIO_DEV_NEW_SA_KUBECONFIG }}
         with:
           args:
             -n ${{ env.K8S_NAMESPACE }} rollout restart deployment ${{ env.K8S_DEPLOYMENT }}

--- a/.github/workflows/mvn-dev-build-deploy.yml
+++ b/.github/workflows/mvn-dev-build-deploy.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   PUBLISH_BRANCH: 'deployment'
-  OKAPI_URL: 'https://orchid-dev-okapi.folio-dev.indexdata.com'
-  OKAPI_SECRET_USER: "${{ secrets.ORCHID_DEV_OKAPI_USER }}"
-  OKAPI_SECRET_PASSWORD: "${{ secrets.ORCHID_DEV_OKAPI_PASSWORD }}"
+  OKAPI_URL: 'https://folio-dev-new-okapi.folio-dev.indexdata.com'
+  OKAPI_SECRET_USER: "${{ secrets.FOLIO_DEV_NEW_OKAPI_USER }}"
+  OKAPI_SECRET_PASSWORD: "${{ secrets.FOLIO_DEV_NEW_OKAPI_PASSWORD }}"
   OK_SESSION: 'session1'
 
 jobs:
@@ -22,10 +22,10 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: recursive
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin' # Alternative distribution options are available.
 
       - name: Prepare okclient
@@ -66,14 +66,11 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Maven build
-        run: mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install org.jacoco:jacoco-maven-plugin:report
-
-      - name: SQ analyze
+      - name: Build and SQ analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=indexdata -Dsonar.projectKey=indexdata_${{ github.event.repository.name }} -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=indexdata -Dsonar.projectKey=indexdata_${{ github.event.repository.name }}
 
       - name: Update ModuleDescriptor Id
         run: |

--- a/.github/workflows/mvn-dev-build-deploy.yml
+++ b/.github/workflows/mvn-dev-build-deploy.yml
@@ -1,0 +1,132 @@
+name: mvn-dev-build-deploy
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+env:
+  PUBLISH_BRANCH: 'deployment'
+  OKAPI_URL: 'https://orchid-dev-okapi.folio-dev.indexdata.com'
+  OKAPI_SECRET_USER: "${{ secrets.ORCHID_DEV_OKAPI_USER }}"
+  OKAPI_SECRET_PASSWORD: "${{ secrets.ORCHID_DEV_OKAPI_PASSWORD }}"
+  OK_SESSION: 'session1'
+
+jobs:
+  mvn-dev-build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin' # Alternative distribution options are available.
+
+      - name: Prepare okclient
+        run: git clone https://github.com/indexdata/okclient
+
+      - name: Ensure OK and FOLIO login
+        # So do not proceed with other workflow steps if not available.
+        run: |
+          source okclient/ok.sh
+          OK -S ${{ env.OK_SESSION }} \
+            -h ${{ env.OKAPI_URL }} \
+            -t "supertenant" \
+            -u ${{ env.OKAPI_SECRET_USER }} \
+            -p ${{ env.OKAPI_SECRET_PASSWORD }}
+          OK -S ${{ env.OK_SESSION }} -x
+
+      - name: Gather some variables
+        run: |
+          echo "MODULE_NAME=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> $GITHUB_ENV
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "CURRENT_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+
+      - name: Set module version
+        run: |
+          echo "MODULE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-${SHA_SHORT}" >> $GITHUB_ENV
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Maven build
+        run: mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install org.jacoco:jacoco-maven-plugin:report
+
+      - name: SQ analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=indexdata -Dsonar.projectKey=indexdata_${{ github.event.repository.name }} -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+
+      - name: Update ModuleDescriptor Id
+        run: |
+          if test -f "$MOD_DESCRIPTOR"; then
+            echo "Found $MOD_DESCRIPTOR"
+            cat <<< $(jq '.id = "${{ env.MODULE_NAME}}-${{ env.MODULE_VERSION }}"' $MOD_DESCRIPTOR) > $MOD_DESCRIPTOR
+            echo "MODULE_DESCRIPTOR=$MOD_DESCRIPTOR" >> $GITHUB_ENV
+          else
+            echo "Could not find $MOD_DESCRIPTOR"
+            exit 1
+          fi
+        env:
+          MOD_DESCRIPTOR: './target/ModuleDescriptor.json'
+
+      - name: Read ModuleDescriptor
+        id: moduleDescriptor
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ${{ env.MODULE_DESCRIPTOR }}
+
+      - name: Login to Index Data Docker Hub account
+        if: ${{ env.CURRENT_BRANCH == env.PUBLISH_BRANCH }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and publish Docker image
+        if: ${{ env.CURRENT_BRANCH == env.PUBLISH_BRANCH }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: indexdata/${{ env.MODULE_NAME }}:${{ env.MODULE_VERSION }},indexdata/${{ env.MODULE_NAME }}:latest
+
+      - name: Publish ModuleDescriptor to Okapi
+        if: ${{ env.CURRENT_BRANCH == env.PUBLISH_BRANCH }}
+        run: |
+          source okclient/ok.sh
+          echo "Do login ..."
+          OK -S ${{ env.OK_SESSION }} \
+            -h ${{ env.OKAPI_URL }} \
+            -t "supertenant" \
+            -u ${{ env.OKAPI_SECRET_USER }} \
+            -p ${{ env.OKAPI_SECRET_PASSWORD }}
+          echo "Post the MD and report the response status ..."
+          OK -S ${{ env.OK_SESSION }} _/proxy/modules \
+            -X post -f ${{ env.MODULE_DESCRIPTOR }}
+          declare -n NAMEREF_STATUS=${{ env.OK_SESSION }}_HTTPStatus
+          echo "Response status: $NAMEREF_STATUS"
+          echo "Do logout ..."
+          OK -S ${{ env.OK_SESSION }} -x
+
+      - name: Print module version to job summary
+        run: |
+          echo "#### Module Version: ${{ env.MODULE_VERSION }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Syncing the ID fork, then updating the deployment branch, from folio-org/mod-circulation removed the k8s and mvn deploy workflows. PR attempts to bring them back. 